### PR TITLE
Finish ReadME

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Heading_Scraper
 Takes an input URL and returns all heading tags within a URL. 
+
+
+Added error exceptions to accomodate incorrect URL's from users. 


### PR DESCRIPTION
Script now accepts all types of domain inputs, raises an error if a '.' is missing.